### PR TITLE
fix: #0FCFA2 → #4ECCA3

### DIFF
--- a/src/gatsby-plugin-theme-ui/index.ts
+++ b/src/gatsby-plugin-theme-ui/index.ts
@@ -5,7 +5,7 @@ const theme = {
     monospace: 'Menlo, monospace',
   },
   colors: {
-    primary: '#0FCFA2',
+    primary: '#4ECCA3',
     secondary: '#1D4C3D',
     dark: '#232931',
     iron: '#393E46',


### PR DESCRIPTION
@AnneMatilde are there other hex colours that are wrong?

```
secondary: '#1D4C3D',
dark: '#232931',
iron: '#393E46',
dry: '#EEEEEE',
lighter: '#53D9AD',
background: '#fff',
text: '#232931',
lightGreen: '#4ECCA3',
```