### PR TITLE
fix: Dependabot doesn't have access to secrets context

### DIFF
--- a/.github/workflows/pull-request-split-workflow.yml
+++ b/.github/workflows/pull-request-split-workflow.yml
@@ -1,0 +1,12 @@
+### Used to split workflow because of potential dependabot vulnerability
+### See https://github.com/dependabot/dependabot-core/issues/3253#issuecomment-852541544
+
+name: Split Workflow
+on:
+  pull_request
+
+jobs:
+  split-workflow:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Split Workflow"

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,6 +1,9 @@
 name: Pull Request
 on:
-  pull_request:
+  workflow_run:
+    workflows: ["Split Workflow"]
+    types: 
+      - completed
     
 jobs:
   pull_request:


### PR DESCRIPTION
A suggested fix for dependabot not having access to secrets context.

Things to concider:
- Add `permissons:` section to pull-request.yml, see https://github.com/dependabot/dependabot-core/issues/3253#issuecomment-852541544

fixes #229 