### PR TITLE
fix: Builds are failing on Dependabot PRs

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -42,6 +42,7 @@ jobs:
 
       - name: Upload website
         uses: FirebaseExtended/action-hosting-deploy@v0
+        if: ${{ github.actor != 'dependabot[bot]' }}
         id: firebase
         with:
           repoToken: '${{ secrets.GITHUB_TOKEN }}'
@@ -53,6 +54,7 @@ jobs:
 
       - name: Get all urls from sitemap.xml
         id: parse-sitemap
+        if: ${{ github.actor != 'dependabot[bot]' }}
         uses: cobraz/parse-sitemap@main
         with:
           sitemap-url: ${{ steps.firebase.outputs.details_url }}/sitemap/sitemap-index.xml
@@ -60,6 +62,7 @@ jobs:
 
       - name: Run Lighthouse
         uses: treosh/lighthouse-ci-action@v7
+        if: ${{ github.actor != 'dependabot[bot]' }}
         with:
           urls: ${{ steps.parse-sitemap.outputs.urls }}
           uploadArtifacts: true


### PR DESCRIPTION
Potential alternate fix for issues described in #229 and [dependabot/dependabot-core#3253](https://github.com/dependabot/dependabot-core/issues/3253#issuecomment-852541544).

Instead of moving to a sub-optimal workflow, I suggest we move away from Dependabot being able to deploy stuff. I'd rather deploy if need be, not have it done in normal operation.

fixes #229
closes #248