### PR TITLE
fix: add text color to theme

### DIFF
--- a/src/components/layout/footer/networks-links.tsx
+++ b/src/components/layout/footer/networks-links.tsx
@@ -11,17 +11,17 @@ export const NetworksLinks: React.FC = props => (
         {
           href: 'https://github.com/bjerkio',
           label: 'Github Profile',
-          icon: <SocialGithub width="100%" height="100%" />,
+          icon: <SocialGithub width="100%" height="100%" color="primary" />,
         },
         {
           href: 'https://www.linkedin.com/company/bjerk/',
           label: 'LinkedIn Profile',
-          icon: <SocialLinkedin width="100%" height="100%" />,
+          icon: <SocialLinkedin width="100%" height="100%" color="primary" />,
         },
         {
           href: 'https://www.facebook.com/WeAreDigitalization',
           label: 'Facebook Profile',
-          icon: <SocialFacebook width="100%" height="100%" />,
+          icon: <SocialFacebook width="100%" height="100%" color="primary" />,
         },
       ].map(({ href, icon, label }, index) => (
         <Link

--- a/src/theme.tsx
+++ b/src/theme.tsx
@@ -19,6 +19,7 @@ export const theme = merge(webTheme, {
   colors: {
     muted: '#95E0C8',
     green120: '#2E896C',
+    text: '#000000',
   },
   /**
    * We should add a few notable sizes here,


### PR DESCRIPTION
It seems this got left out of the changes in #340 

(The links turned green)

This issue is a bit mysterious, since `text` is actually defined in `@bjerk/brand`. Perhaps this is not the right solution