### PR TITLE
feat: add booking button to about section

### DIFF
--- a/src/components/booking.tsx
+++ b/src/components/booking.tsx
@@ -2,7 +2,11 @@ import React from 'react';
 import { openPopupWidget } from 'react-calendly';
 import { Button } from 'theme-ui';
 
-export const Booking: React.FC = () => {
+export interface BookingProps {
+  label?: string;
+}
+
+export const Booking: React.FC<BookingProps> = ({ label }) => {
   const onClick = () =>
     openPopupWidget({ url: 'https://calendly.com/simen-a-w-olsen' });
   return (
@@ -10,7 +14,7 @@ export const Booking: React.FC = () => {
       sx={{ color: 'iron', width: 'fit-content', cursor: 'pointer' }}
       onClick={onClick}
     >
-      Book et møte →
+      {label ? label : 'Book et møte →'}
     </Button>
   );
 };

--- a/src/components/layout/footer/footer.tsx
+++ b/src/components/layout/footer/footer.tsx
@@ -12,7 +12,7 @@ export const Footer: React.FC = () => (
         <Logo sx={{ height: '30px', mr: 'auto', color: 'white' }} />
         <Grid columns={[1, '3fr 2fr 2fr']}>
           <Box>
-            <Booking />
+            <Booking label={'Book et møte →'} />
           </Box>
 
           <Flex sx={{ flexDirection: 'column', gap: 1 }}>

--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -8,6 +8,7 @@ import {
   Link as ThemeUILink,
 } from 'theme-ui';
 import { ContactPerson } from '../components/about/contact-person';
+import { Booking } from '../components/booking';
 import { Layout } from '../components/layout/layout';
 
 const About: React.FC = () => {
@@ -66,7 +67,7 @@ const About: React.FC = () => {
             </ThemeUILink>
           </Grid>
         </Grid>
-
+        <Booking label={'Sett opp et møte med oss'} />
         <Flex
           sx={{
             flexDirection: ['column', 'row'],


### PR DESCRIPTION
This button is there in the design but is lacking in the current implementation

- Add prop to `Booking` that lets you specify a custom label for the button
- Add button to `About` with label from Figma