### PR TITLE
feat: style link element to look like button

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,15 +1,6 @@
 import type { NextPage } from 'next';
 import { Link } from 'next-theme-ui';
-import {
-  Box,
-  Button,
-  Card,
-  Grid,
-  Heading,
-  Image,
-  Paragraph,
-  Text,
-} from 'theme-ui';
+import { Box, Card, Grid, Heading, Image, Paragraph, Text } from 'theme-ui';
 import { Layout } from '../components/layout/layout';
 const customers = [
   'grid-branding',

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -27,7 +27,7 @@ const Home: NextPage = () => {
           <Box>
             <Link
               href={'/about'}
-              sx={{ textDecoration: 'none', variant: 'links.buttonLike' }}
+              sx={{ textDecoration: 'none', variant: 'links.buttonLink' }}
             >
               Les mer om oss
             </Link>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -34,8 +34,11 @@ const Home: NextPage = () => {
             jobber, og kommuniserer på.
           </Paragraph>
           <Box>
-            <Link href={'/about'} sx={{ textDecoration: 'none' }}>
-              <Button sx={{ cursor: 'pointer' }}>Les mer om oss</Button>
+            <Link
+              href={'/about'}
+              sx={{ textDecoration: 'none', variant: 'links.buttonLike' }}
+            >
+              Les mer om oss
             </Link>
           </Box>
         </Grid>

--- a/src/theme.tsx
+++ b/src/theme.tsx
@@ -75,6 +75,15 @@ export const theme = merge(webTheme, {
       fontSize: 2,
     },
   },
+  links: {
+    buttonLike: {
+      borderRadius: 1,
+      backgroundColor: 'black100',
+      p: 3,
+      fontSize: 2,
+      color: 'white',
+    },
+  },
   /**
    * Read more: https://github.com/bjerkio/brand/issues/7
    */

--- a/src/theme.tsx
+++ b/src/theme.tsx
@@ -19,6 +19,7 @@ export const theme = merge(webTheme, {
   colors: {
     muted: '#95E0C8',
     green120: '#2E896C',
+    foreground: '#ffffff',
   },
   /**
    * We should add a few notable sizes here,
@@ -76,12 +77,11 @@ export const theme = merge(webTheme, {
     },
   },
   links: {
-    buttonLike: {
+    buttonLink: {
+      variant: 'buttons.primary',
       borderRadius: 1,
-      backgroundColor: 'black100',
-      p: 3,
-      fontSize: 2,
-      color: 'white',
+      color: 'foreground',
+      width: 'fit-content',
     },
   },
   /**


### PR DESCRIPTION
This gives better accessibility.

Currently, when using a keyboard to navigate the site, the `Button` inside a `Link` causes you to tab through both of those elements individually, which is not a good user experience.

According to some [people on stackoverflow](https://stackoverflow.com/questions/37391205/is-it-bad-accessibility-practice-to-style-a-link-like-a-button), it's not good practice to style a link as a button, but it's miles better than having a button that behaves like an anchor.