### PR TITLE
fix: hamburger/cross placed correctly

### DIFF
--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -22,7 +22,7 @@ export const Header: React.FC = () => {
       }}
     >
       {menuIsOpen && (
-        <Flex 
+        <Flex
           sx={{
             position: 'fixed',
             left: 0,
@@ -32,12 +32,11 @@ export const Header: React.FC = () => {
             height: '100vh',
             zIndex: 2,
             display: ['flex', 'none'],
-            p:6,
+            p: 6,
             gap: 6,
             flexDirection: 'column',
             alignItems: 'center',
             overflow: 'scroll',
-            
           }}
         >
           <Flex
@@ -66,7 +65,7 @@ export const Header: React.FC = () => {
               alignItems: 'center',
               gap: 6,
               height: '70%',
-              mt:8
+              mt: 8,
             }}
           >
             <Flex

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -22,7 +22,7 @@ export const Header: React.FC = () => {
       }}
     >
       {menuIsOpen && (
-        <Flex
+        <Flex 
           sx={{
             position: 'fixed',
             left: 0,
@@ -32,13 +32,12 @@ export const Header: React.FC = () => {
             height: '100vh',
             zIndex: 2,
             display: ['flex', 'none'],
-            px: 5,
-            pt: 5,
-            pb: 0,
-            gap: 5,
+            p:6,
+            gap: 6,
             flexDirection: 'column',
             alignItems: 'center',
             overflow: 'scroll',
+            
           }}
         >
           <Flex
@@ -49,11 +48,10 @@ export const Header: React.FC = () => {
             />
             <IconButton
               sx={{
-                width: '45px',
-                height: '25px',
+                width: '30px',
+                height: '30px',
                 backgroundColor: 'dark100',
                 ml: 'auto',
-                mt:'12px'
               }}
               onClick={() => setMenuIsOpen(false)}
             >
@@ -64,14 +62,15 @@ export const Header: React.FC = () => {
           <Flex
             sx={{
               flexDirection: 'column',
-              justifyContent: 'center',
+              justifyContent: 'flex-start',
               alignItems: 'center',
               gap: 6,
               height: '70%',
+              mt:8
             }}
           >
             <Flex
-              sx={{ flexDirection: 'column', alignItems: 'center', gap: 6 }}
+              sx={{ flexDirection: 'column', alignItems: 'center', gap: 3 }}
             >
               <Link variant="mobileNav" href="/about">
                 Om oss
@@ -117,9 +116,8 @@ export const Header: React.FC = () => {
             sx={{
               display: ['block', 'none'],
               ml: 'auto',
-              width: '40px',
-              height: '25px',
-              alignSelf: 'flex-start'
+              width: '30px',
+              height: '30px',
             }}
             onClick={() => setMenuIsOpen(!menuIsOpen)}
           >

--- a/src/components/layout/header/hamburger.tsx
+++ b/src/components/layout/header/hamburger.tsx
@@ -6,8 +6,8 @@ type Props = ThemeUIStyleObject & SVGProps<SVGSVGElement>;
 export const Hamburger: FC<Props> = () => {
   return (
     <svg
-      width="32"
-      height="22"
+      width="26"
+      height="26"
       viewBox="0 0 32 22"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
* fix: hamburger/cross placed correctly - now also scalable at all resolutions
* feat: move mobile menu up and decrease the space between the buttons.