### PR TITLE
fix: remove google sitemap ping

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -71,7 +71,3 @@ jobs:
           channelId: live
           target: prod
           projectId: bjerk-io
-
-      - uses: atymic/sitemap-ping-action@master
-        with:
-          sitemap-url: https://bjerk.io/sitemap-index.xml


### PR DESCRIPTION
It's deprecated 🤷 

https://developers.google.com/search/blog/2023/06/sitemaps-lastmod-ping