### PR TITLE
feat: add well-known matrix file

### DIFF
--- a/src/content/people/mats-moglestue.json
+++ b/src/content/people/mats-moglestue.json
@@ -16,4 +16,4 @@
     }
   ],
   "photographerName": "Simen A. W. Olsen"
-} 
+}

--- a/src/pages/.well-known/matrix/server.ts
+++ b/src/pages/.well-known/matrix/server.ts
@@ -2,7 +2,7 @@ export async function GET() {
   return new Response(
     JSON.stringify(
       {
-        'm.server': 'matrix.bjerk.io:443',
+        "m.server": "matrix.bjerk.io:443",
       },
       null,
       2,

--- a/src/pages/.well-known/matrix/server.ts
+++ b/src/pages/.well-known/matrix/server.ts
@@ -1,0 +1,11 @@
+export async function GET() {
+  return new Response(
+    JSON.stringify(
+      {
+        'm.server': 'matrix.bjerk.io:443',
+      },
+      null,
+      2,
+    ),
+  );
+}


### PR DESCRIPTION
This is necessary for receiving traffic to our matrix server which will be hosted on matrix.bjerk.io but is identified publicly with the `:bjerk.io` address

See the [delegation docs](https://github.com/matrix-org/synapse/blob/develop/docs/delegate.md) for more info