### PR TITLE
move primary button to global

### DIFF
--- a/src/layouts/default.astro
+++ b/src/layouts/default.astro
@@ -245,6 +245,18 @@ const canonical = new URL(path, Astro.site);
         color: #1d1d1d;
       }
 
+      .primary {
+        font-size: 1rem;
+        padding: 0.25rem 1rem;
+        border-radius: 16px;
+        border: solid;
+        border-width: 2px;
+        border-color: hsl(var(--green-base) 75%);
+        text-decoration: none;
+        background-color: white;
+        width: fit-content;
+      }
+
       body *::-webkit-scrollbar {
         background-color: hsl(var(--blue-base) 90%);
       }

--- a/src/layouts/default.astro
+++ b/src/layouts/default.astro
@@ -246,7 +246,7 @@ const canonical = new URL(path, Astro.site);
       }
 
       .primary {
-        font-size: 1rem;
+        font-size: 1em;
         padding: 0.25rem 1rem;
         border-radius: 16px;
         border: solid;

--- a/src/layouts/default.astro
+++ b/src/layouts/default.astro
@@ -246,7 +246,7 @@ const canonical = new URL(path, Astro.site);
       }
 
       .primary {
-        font-size: 1em;
+        font-size: 1rem;
         padding: 0.25rem 1rem;
         border-radius: 16px;
         border: solid;
@@ -255,6 +255,13 @@ const canonical = new URL(path, Astro.site);
         text-decoration: none;
         background-color: white;
         width: fit-content;
+      }
+      .primary:hover {
+        background-color: hsl(var(--green-base) 75%);
+      }
+      .primary:active {
+        border-color: hsl(var(--green-base) 55%);
+        background-color: hsl(var(--green-base) 55%);
       }
 
       body *::-webkit-scrollbar {

--- a/src/layouts/default.astro
+++ b/src/layouts/default.astro
@@ -31,12 +31,12 @@ export type Props = {
    */
   headline?: string;
 
-    /**
+  /**
    * The heading on the page next to headline. Should be longer than headline.
    *
    * @default title
    */
-   heading?: string;
+  heading?: string;
 
   /**
    * The title for social media platforms. The ideal length is approximately 47 characters.
@@ -290,6 +290,33 @@ const canonical = new URL(path, Astro.site);
         text-decoration-skip-ink: none;
         text-decoration-thickness: 0.125em;
         text-underline-offset: 0.125em;
+      }
+
+      input,
+      textarea {
+        width: auto;
+        padding: 1em;
+        resize: none;
+        font-family:
+          'Sora Variable',
+          system-ui,
+          -apple-system,
+          sans-seri;
+        transition: all 0.5s ease;
+        max-width: 60ch;
+      }
+      input {
+        border: none;
+        border-block-end: 1px solid grey;
+        padding: 16px 0;
+      }
+      textarea {
+        border-radius: 8px;
+      }
+
+      input:focus {
+        background-color: hsl(var(--blue-base) 95%);
+        padding: 16px 1em;
       }
 
       @media (hover) {

--- a/src/pages/kontakt/index.astro
+++ b/src/pages/kontakt/index.astro
@@ -105,7 +105,7 @@ const employees = people.filter(person => person.data.email.includes('@bjerk.io'
             </div>
             <div class="issue">
               <textarea placeholder="Hva dreier deg seg om?" name="text" id="text" rows="5" required />
-              <input type="submit" value="Send inn" id="submit">
+              <button class="primary" type="submit" id="submit">Send inn</button>
             </div>
           </form>    
         </section>
@@ -199,20 +199,9 @@ const employees = people.filter(person => person.data.email.includes('@bjerk.io'
     gap: 1rem;
   }
   form .issue {
-    display: grid;
-    grid-template-columns: 1fr;
+    display: flex;
+    flex-direction: column;
     gap: 1rem;
-  }
-  form #submit {
-    font-size: 1rem;
-    padding: 0.25rem 1rem;
-    border-radius: 16px;
-    border: solid;
-    border-width: 2px;
-    border-color: hsl(var(--green-base) 75%);
-    text-decoration: none;
-    background-color: white;
-    width: fit-content;
   }
   form #submit:hover {
     background-color: hsl(var(--green-base) 75%);

--- a/src/pages/kontakt/index.astro
+++ b/src/pages/kontakt/index.astro
@@ -203,13 +203,6 @@ const employees = people.filter(person => person.data.email.includes('@bjerk.io'
     flex-direction: column;
     gap: 1rem;
   }
-  form #submit:hover {
-    background-color: hsl(var(--green-base) 75%);
-  }
-  form #submit:active {
-    border-color: hsl(var(--green-base) 55%);
-    background-color: hsl(var(--green-base) 55%);
-  }
   .employees {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(244px, 1fr));

--- a/src/pages/kontakt/index.astro
+++ b/src/pages/kontakt/index.astro
@@ -164,31 +164,6 @@ const employees = people.filter(person => person.data.email.includes('@bjerk.io'
   dl div > dd a {
     color: inherit;
   }
-  input, textarea {
-    width: auto;
-    padding: 1em;
-    resize: none;
-    font-family:
-    'Sora Variable',
-    system-ui,
-    -apple-system,
-    sans-seri;
-    transition: all 0.5s ease;
-    max-width: 60ch;
-  }
-  input {
-    border: none;
-    border-block-end: 1px solid grey;
-    padding: 16px 0;
-  }
-  textarea {
-    border-radius: 8px;
-  }
-
-  input:focus {
-    background-color: hsl(var(--blue-base) 95%);
-    padding: 16px 1em;
-  }
   form {
     display: flex;
     flex-direction: column;

--- a/src/pages/kontakt/index.astro
+++ b/src/pages/kontakt/index.astro
@@ -164,19 +164,15 @@ const employees = people.filter(person => person.data.email.includes('@bjerk.io'
   dl div > dd a {
     color: inherit;
   }
-  form {
-    display: flex;
-    flex-direction: column;
-    gap: 2em;
-  }
-  form .identity {
-    display: grid;
-    gap: 1rem;
-  }
+  form,
+  form .identity,
   form .issue {
     display: flex;
     flex-direction: column;
     gap: 1rem;
+  }
+  form {
+    gap: 2rem;
   }
   .employees {
     display: grid;


### PR DESCRIPTION
### TL;DR:
moving the form submission button to be a standard re-usable component

### What's changed

This moves the `form#submit` into a more generic `primary` class. This way we can re-use this button elsewhere on the app 🙌 

### Why

We probably want to use this button elsewhere and having a generic one will help with re-using things while also reducing the css specific to contact page