### PR TITLE
refactor: set margin on slot instead of specific footer

### DIFF
--- a/src/components/contact-footer.astro
+++ b/src/components/contact-footer.astro
@@ -19,7 +19,6 @@ import ContactForm from '@components/contact-form.astro';
 
 <style>
   .contact-footer {
-    margin-top: 4rem;
     background-color: hsl(var(--blue-base) 95%);
   }
 

--- a/src/layouts/default.astro
+++ b/src/layouts/default.astro
@@ -197,9 +197,7 @@ const canonical = new URL(path, Astro.site);
   </head>
   <body>
     <Header />
-    <div class="slot">
-      <slot />
-    </div>
+    <slot />
     {
       contactFooter && 
       <ContactFooter />
@@ -238,7 +236,7 @@ const canonical = new URL(path, Astro.site);
         -moz-osx-font-smoothing: grayscale;
         font-feature-settings: 'kern', 'liga';
       }
-      .slot {
+      main {
         margin-bottom: 4rem;
       }
 

--- a/src/layouts/default.astro
+++ b/src/layouts/default.astro
@@ -191,8 +191,13 @@ const canonical = new URL(path, Astro.site);
   </head>
   <body>
     <Header />
-    <slot />
-    <ContactFooter />
+    <div class="slot">
+      <slot />
+    </div>
+    {
+      path !== "/kontakt" && 
+      <ContactFooter />
+    }
     <Footer />
     <style is:global>
       :root {
@@ -212,7 +217,6 @@ const canonical = new URL(path, Astro.site);
         --border-radius: 0.25rem;
         --border-radius-sm: 0.125rem;
       }
-
       html {
         font-family:
           'Sora Variable',
@@ -227,6 +231,9 @@ const canonical = new URL(path, Astro.site);
         -webkit-font-smoothing: antialiased;
         -moz-osx-font-smoothing: grayscale;
         font-feature-settings: 'kern', 'liga';
+      }
+      .slot {
+        margin-bottom: 4rem;
       }
 
       body {

--- a/src/layouts/default.astro
+++ b/src/layouts/default.astro
@@ -87,6 +87,11 @@ export type Props = {
   articleAuthor?: string;
 
   /**
+   * Set to false for pages that shouldn't have a contact form at the bottom.
+   */
+  contactFooter?: boolean;
+
+  /**
    * JSON-LD structured data for the page.
    */
   schema?: WithContext<Thing> | WithContext<Thing>[];
@@ -113,6 +118,7 @@ const {
   schema,
   articleAuthor,
   articlePublishDate,
+  contactFooter = true,
 } = Astro.props;
 
 // const parsedImages = images.map((image) => parseSocialMediaImage(image));
@@ -195,7 +201,7 @@ const canonical = new URL(path, Astro.site);
       <slot />
     </div>
     {
-      path !== "/kontakt" && 
+      contactFooter && 
       <ContactFooter />
     }
     <Footer />

--- a/src/pages/kontakt/index.astro
+++ b/src/pages/kontakt/index.astro
@@ -28,6 +28,7 @@ const employees = people.filter(person => person.data.email.includes('@bjerk.io'
   socialMediaTitle="🚀 Start samtalen med Bjerk: Bli med å skap noe med oss!"
   socialMediaDescription="Start en samtale med Bjerk i dag for å lage skreddersydde løsningerog få tilgang på ekspertise innen digital innovasjon."
   path="/kontakt"
+  contactFooter={false}
   schema={{
     '@context': 'https://schema.org',
     '@type': 'ProfessionalService',


### PR DESCRIPTION
### TL;DR:

This makes it so the margin to keep distance between slot and footer is not based on which footer is shown.

### What's changed

a simple refactor where we move what html has margin top / bottom.

### Why

This can be done in 1 of 2 ways:

Option 1: we move the contact footer to be in main footer file, and that footer has margin top -> then show the two footers

Option 2: we do this where we wrap the slot in a div and add a margin at its bottom instead