### PR TITLE
feat: add gdpr compliance info

### DIFF
--- a/src/components/contact-form.astro
+++ b/src/components/contact-form.astro
@@ -2,7 +2,6 @@
 ---
 
 <form action="">
-  <div>
     <input
       placeholder="E-postadresse"
       type="text"
@@ -10,7 +9,6 @@
       id="name"
       required
     />
-  </div>
   <div>
     <textarea
       placeholder="Hva dreier deg seg om?"

--- a/src/components/contact-form.astro
+++ b/src/components/contact-form.astro
@@ -16,8 +16,7 @@
       id="text"
       rows="5"
       required
-    >
-    </textarea>
+    />
     <button class="primary" type="submit" id="submit">Send inn</button>
   </div>
 </form>

--- a/src/components/contact-form.astro
+++ b/src/components/contact-form.astro
@@ -17,6 +17,12 @@
       rows="5"
       required
     />
+    <p>
+      Ved å sende inn dette skjemaet godtar du at vi lagrer og behandler
+      personopplysningene dine. Les mer om hvordan vi behandler personopplysninger
+      i vår
+      <a href="/personvern">personvernerklæring</a>.
+    </p>
     <button class="primary" type="submit" id="submit">Send inn</button>
   </div>
 </form>
@@ -30,5 +36,10 @@
   }
   form {
     gap: 2rem;
+  }
+  p {
+    font-size: 12px;
+    font-weight: lighter;
+    margin: 0;
   }
 </style>


### PR DESCRIPTION
### TL;DR

Adding gdpr information for contact form

### What's changed

* removed redundant div (semantic)
* fixed bug with textarea filling out blank space as default value
* Added GPDR information to mention that we 

### Why 

This helps cover if we want to store the user as a contact beyond the first call on the case they submitted 