### PR TITLE
Feat: Add image alt text and image resizing

### DIFF
--- a/src/components/intro-card.astro
+++ b/src/components/intro-card.astro
@@ -1,12 +1,19 @@
 ---
+import { Image } from 'astro:assets';
+
 interface Props {
   image: ImageMetadata
+  imageAlt: string
 };
 
-const { image } = Astro.props;
+const { image, imageAlt } = Astro.props;
 ---
 <div class="card">
-  <img src={image.src} />
+  <Image 
+  src={image}
+  alt={imageAlt}
+  width={400} 
+  />
   <div class="intro-content">
     <slot />
   </div>
@@ -15,6 +22,7 @@ const { image } = Astro.props;
 <style>
   img {
     width: 200px;
+    height: auto;
     aspect-ratio: 1 / 1;
     border-radius: 1em;
     object-fit: cover;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -13,6 +13,7 @@ const url = Astro.site;
 const introCards = [
   {
     image: CreateSomethingNewImage,
+    imageAlt: "Bilde av stammen til et bjørketre ved noen steiner",
     title: 'Skreddersydd programvare',
     description: `
       Se for deg en løsning som er unikt tilpasset dine behov, skaper enda bedre arbeidsflyer, og gir deg
@@ -21,6 +22,7 @@ const introCards = [
   },
   {
     image: IntegrationsImage,
+    imageAlt: "Naturbilde av bjørketrær med løv på bakken",
     title: 'Skap effektivitet og vekst med egne integrasjoner',
     description: `
       Ved å sy sammen de ulike systemene i bedriften kan du legge til rette for sømløse arbeidsflyer og 
@@ -30,6 +32,7 @@ const introCards = [
   },
   {
     image: ImproveExistingSystemsImage,
+    imageAlt: "Grønt naturbilde med bjerktrær",
     title: 'Forbedre eksisterende systemer',
     description: `
       Noen ganger det best å bygge videre på det du allerede har invistert i. Ved å videreutvikle dine
@@ -69,7 +72,7 @@ const introCards = [
     <section class="intro-cards">
       {
         introCards.map(item => (
-          <IntroCard image={item.image}>
+          <IntroCard image={item.image} imageAlt={item.imageAlt}>
             <div class="intro-content">
               <h2>{item.title}</h2>
               <p>{item.description}</p>


### PR DESCRIPTION
[Astro's Image component](https://docs.astro.build/en/guides/images/#image--astroassets) can resize images so we don't serve the full resolution image. It also requires alt text for accessibilty. 

Using 400px width for 200px image since it looks significantly better than 200 and is still quite small.

Height auto to enforce the aspect ratio.

Manually added image alt text since the title doesn't describe it.